### PR TITLE
chore: remove pre-commit package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "chai": "^4.1.2",
     "dirty-chai": "^2.0.1",
     "multihashing": "~0.3.2",
-    "multihashing-async": "~0.5.1",
-    "pre-commit": "^1.2.2"
+    "multihashing-async": "~0.5.1"
   },
   "engines": {
     "node": ">=4.0.0",


### PR DESCRIPTION
Git hooks are now handled directly by aegir (with git-validate).
Hence the pre-commit package is no longer needed.