### PR TITLE
Multicodec constants

### DIFF
--- a/src/cid-util.js
+++ b/src/cid-util.js
@@ -20,8 +20,16 @@ var CIDUtil = {
       return 'Invalid version, must be a number equal to 1 or 0'
     }
 
-    if (typeof other.codec !== 'string') {
-      return 'codec must be string'
+    // Only check codec if code isn't set. That's the case for older CIDs
+    // create with cids < 0.6.
+    if (other.code !== undefined) {
+      if (typeof other.code !== 'number') {
+        return 'code must be a number'
+      }
+    } else {
+      if (typeof other.codec !== 'string') {
+        return 'codec must be a string'
+      }
     }
 
     if (!Buffer.isBuffer(other.multihash)) {

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ class CID {
    */
   constructor (version, codec, multihash) {
     if (module.exports.isCID(version)) {
-      let cid = version
+      const cid = version
       this.version = cid.version
       this.codec = cid.codec
       this.multihash = Buffer.from(cid.multihash)
@@ -72,7 +72,8 @@ class CID {
     if (typeof version === 'string') {
       if (multibase.isEncoded(version)) { // CID String (encoded with multibase)
         const cid = multibase.decode(version)
-        version = parseInt(cid.slice(0, 1).toString('hex'), 16)
+        const firstByte = cid.slice(0, 1)
+        version = parseInt(firstByte.toString('hex'), 16)
         codec = multicodec.getCodec(cid.slice(1))
         multihash = multicodec.rmPrefix(cid.slice(1))
       } else { // bs58 string encoded multihash
@@ -81,16 +82,15 @@ class CID {
         version = 0
       }
     } else if (Buffer.isBuffer(version)) {
-      const firstByte = version.slice(0, 1)
-      const v = parseInt(firstByte.toString('hex'), 16)
-      if (v === 0 || v === 1) { // CID
-        const cid = version
-        version = v
+      const cid = version
+      const firstByte = cid.slice(0, 1)
+      version = parseInt(firstByte.toString('hex'), 16)
+      if (version === 0 || version === 1) { // CID
         codec = multicodec.getCodec(cid.slice(1))
         multihash = multicodec.rmPrefix(cid.slice(1))
       } else { // multihash
         codec = 'dag-pb'
-        multihash = version
+        multihash = cid
         version = 0
       }
     }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -8,6 +8,7 @@ const expect = chai.expect
 chai.use(dirtyChai)
 const multihash = require('multihashes')
 const multihashing = require('multihashing-async')
+const multicodec = require('multicodec')
 
 const CID = require('../src')
 
@@ -30,6 +31,7 @@ describe('CID', () => {
       const cid = new CID(mhStr)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', multicodec.DAG_PB)
       expect(cid).to.have.property('version', 0)
       expect(cid).to.have.property('multihash').that.eql(multihash.fromB58String(mhStr))
 
@@ -44,6 +46,7 @@ describe('CID', () => {
         const cid = new CID(mh)
 
         expect(cid).to.have.property('codec', 'dag-pb')
+        expect(cid).to.have.property('code', multicodec.DAG_PB)
         expect(cid).to.have.property('version', 0)
         expect(cid).to.have.property('multihash').that.eql(mh)
 
@@ -56,6 +59,7 @@ describe('CID', () => {
       const cid = new CID(0, 'dag-pb', hash)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', multicodec.DAG_PB)
       expect(cid).to.have.property('version', 0)
       expect(cid).to.have.property('multihash')
     })
@@ -94,6 +98,7 @@ describe('CID', () => {
       const cid = new CID(cidStr)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', multicodec.DAG_PB)
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
 
@@ -107,6 +112,7 @@ describe('CID', () => {
       const cid = new CID(cidBuf)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', multicodec.DAG_PB)
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
 
@@ -117,6 +123,16 @@ describe('CID', () => {
       const cid = new CID(1, 'dag-cbor', hash)
 
       expect(cid).to.have.property('codec', 'dag-cbor')
+      expect(cid).to.have.property('code', multicodec.DAG_CBOR)
+      expect(cid).to.have.property('version', 1)
+      expect(cid).to.have.property('multihash')
+    })
+
+    it('can be created by parts with multicodec constant', () => {
+      const cid = new CID(1, multicodec.DAG_CBOR, hash)
+
+      expect(cid).to.have.property('codec', 'dag-cbor')
+      expect(cid).to.have.property('code', multicodec.DAG_CBOR)
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
     })
@@ -126,6 +142,7 @@ describe('CID', () => {
       const cid2 = new CID(cid1.toBaseEncodedString())
 
       expect(cid1).to.have.property('codec').that.eql(cid2.codec)
+      expect(cid1).to.have.property('code').that.eql(cid2.code)
       expect(cid1).to.have.property('version').that.eql(cid2.version)
       expect(cid1).to.have.property('multihash').that.eql(cid2.multihash)
     })
@@ -137,9 +154,11 @@ describe('CID', () => {
       const cid2 = new CID(cid1.toBaseEncodedString())
 
       expect(cid1).to.have.property('codec', 'eth-block')
+      expect(cid1).to.have.property('code', multicodec.ETH_BLOCK)
       expect(cid1).to.have.property('version', 1)
       expect(cid1).to.have.property('multihash').that.eql(mh)
       expect(cid2).to.have.property('codec', 'eth-block')
+      expect(cid2).to.have.property('code', multicodec.ETH_BLOCK)
       expect(cid2).to.have.property('version', 1)
       expect(cid2).to.have.property('multihash').that.eql(mh)
     })


### PR DESCRIPTION
The codec used to be defined as string. Now you can use the numbers as
defined per multicodec constants. The codec is stored in a field
called `code`.

Ideally we would store it in `codec`, but for backwards compatibility
reasons that one will still return the name of the codec as a string.

New code should use `code` instead of `codec` to check for the codec
a CID is using.

This change needs https://github.com/multiformats/js-multicodec/pull/35 to be merged first.