### PR TITLE
refactor: base32 encode CIDs by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,21 +185,21 @@ class CID {
   /**
    * Encode the CID into a string.
    *
-   * @param {string} [base='base58btc'] - Base encoding to use.
+   * @param {string} [base='base32'] - Base encoding to use. For v0 CIDs this
+   * defaults to 'base58btc' and if passed MUST have that value. For v1 CIDs
+   * it defaults to base32.
    * @returns {string}
    */
   toBaseEncodedString (base) {
-    base = base || 'base58btc'
-
     switch (this.version) {
       case 0: {
-        if (base !== 'base58btc') {
+        if (base && base !== 'base58btc') {
           throw new Error('not supported with CIDv0, to support different bases, please migrate the instance do CIDv1, you can do that through cid.toV1()')
         }
         return mh.toB58String(this.multihash)
       }
       case 1:
-        return multibase.encode(base, this.buffer).toString()
+        return multibase.encode(base || 'base32', this.buffer).toString()
       default:
         throw new Error('Unsupported version')
     }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -97,7 +97,7 @@ describe('CID', () => {
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
 
-      expect(cid.toBaseEncodedString()).to.be.eql(cidStr)
+      expect(cid.toBaseEncodedString('base58btc')).to.be.eql(cidStr)
     })
 
     it('handles CID (no multibase)', () => {
@@ -110,7 +110,7 @@ describe('CID', () => {
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
 
-      expect(cid.toBaseEncodedString()).to.be.eql(cidStr)
+      expect(cid.toBaseEncodedString('base58btc')).to.be.eql(cidStr)
     })
 
     it('create by parts', () => {


### PR DESCRIPTION
BREAKING CHANGE: `toString` and `toBaseEncodedString` will now use base32 encoding to encode version 1 CIDs by default.