### PR TITLE
perf: cache buffer form of CID when created

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,18 +122,26 @@ class CID {
    * @memberOf CID
    */
   get buffer () {
-    switch (this.version) {
-      case 0:
-        return this.multihash
-      case 1:
-        return Buffer.concat([
+    let buffer = this._buffer
+
+    if (!buffer) {
+      if (this.version === 0) {
+        buffer = this.multihash
+      } else if (this.version === 1) {
+        buffer = Buffer.concat([
           Buffer.from('01', 'hex'),
           multicodec.getCodeVarint(this.codec),
           this.multihash
         ])
-      default:
+      } else {
         throw new Error('unsupported version')
+      }
+
+      // Cache this buffer so it doesn't have to be recreated
+      Object.defineProperty(this, '_buffer', { value: buffer })
     }
+
+    return buffer
   }
 
   /**

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -300,4 +300,15 @@ describe('CID', () => {
       })
     })
   })
+
+  describe('buffer reuse', () => {
+    it('should cache CID as buffer', done => {
+      multihashing(Buffer.from(`TEST${Date.now()}`), 'sha2-256', (err, hash) => {
+        if (err) return done(err)
+        const cid = new CID(1, 'dag-pb', hash)
+        expect(cid.buffer).to.equal(cid.buffer)
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
I quickly threw this together in response to https://github.com/ipfs/js-ipfs/issues/1788.

Right now, when attempting to get content not in the local repo, `cid.buffer` will be requested multiple times. See:

https://github.com/ipfs/js-ipfs-repo/blob/01a47375f5a07c5b9b3312c1674923a3c2854ae8/src/blockstore.js#L163-L171

`cidToDsKey` accesses `cid.buffer` and will be called twice in this one method (and possibly other times throughout the code base) so in this case it is worth the overhead of caching the buffer because recreating it is expensive.

resolves https://github.com/ipfs/js-ipfs/issues/1788
