### PR TITLE
feat: preserve base when constructed from a string

### DIFF
--- a/src/cid-util.js
+++ b/src/cid-util.js
@@ -24,6 +24,15 @@ var CIDUtil = {
       return 'codec must be string'
     }
 
+    if (other.version === 0) {
+      if (other.codec !== 'dag-pb') {
+        return `codec must be 'dag-pb' for CIDv0`
+      }
+      if (other.multibaseName !== 'base58btc') {
+        return `multibaseName must be 'base58btc' for CIDv0`
+      }
+    }
+
     if (!Buffer.isBuffer(other.multihash)) {
       return 'multihash must be a Buffer'
     }

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,7 @@ class CID {
         this.multibaseName = 'base58btc'
       }
       CID.validateCID(this)
+      Object.defineProperty(this, 'string', { value: version })
       return
     }
 
@@ -221,18 +222,25 @@ class CID {
    * @returns {string}
    */
   toBaseEncodedString (base = this.multibaseName) {
-    switch (this.version) {
-      case 0: {
-        if (base !== 'base58btc') {
-          throw new Error('not supported with CIDv0, to support different bases, please migrate the instance do CIDv1, you can do that through cid.toV1()')
-        }
-        return mh.toB58String(this.multihash)
-      }
-      case 1:
-        return multibase.encode(base, this.buffer).toString()
-      default:
-        throw new Error('Unsupported version')
+    if (this.string && base === this.multibaseName) {
+      return this.string
     }
+    let str = null
+    if (this.version === 0) {
+      if (base !== 'base58btc') {
+        throw new Error('not supported with CIDv0, to support different bases, please migrate the instance do CIDv1, you can do that through cid.toV1()')
+      }
+      str = mh.toB58String(this.multihash)
+    } else if (this.version === 1) {
+      str = multibase.encode(base, this.buffer).toString()
+    } else {
+      throw new Error('unsupported version')
+    }
+    if (base === this.multibaseName) {
+      // cache the string value
+      Object.defineProperty(this, 'string', { value: str })
+    }
+    return str
   }
 
   toString (base) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -167,6 +167,32 @@ describe('CID', () => {
     })
   })
 
+  describe('.toString', () => {
+    it('returns a CID string', () => {
+      const cid = new CID(hash)
+      expect(cid.toString()).to.equal('QmatYkNGZnELf8cAGdyJpUca2PyY4szai3RHyyWofNY1pY')
+    })
+
+    it('returns a string in the same base as the string passed to the constructor - base64 flavour', () => {
+      const base64Str = 'mAXASIOnrbGCADfkPyOI37VMkbzluh1eaukBqqnl2oFaFnuIt'
+      const cid = new CID(base64Str)
+      expect(cid.toString()).to.equal(base64Str)
+    })
+
+    it('returns a string in the same base as the string passed to the constructor - base16 flavour', () => {
+      const base16Str = 'f01701220e9eb6c60800df90fc8e237ed53246f396e87579aba406aaa7976a056859ee22d'
+      const cid = new CID(base16Str)
+      expect(cid.toString()).to.equal(base16Str)
+    })
+
+    it('returns a string in the base provided', () => {
+      const b58v1Str = 'zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS'
+      const b32v1Str = 'bafybeidskjjd4zmr7oh6ku6wp72vvbxyibcli2r6if3ocdcy7jjjusvl2u'
+      const cid = new CID(b58v1Str)
+      expect(cid.toString('base32')).to.equal(b32v1Str)
+    })
+  })
+
   describe('utilities', () => {
     const h1 = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
     const h2 = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1o'
@@ -206,19 +232,6 @@ describe('CID', () => {
       expect(
         CID.isCID(new CID(h1).toV1())
       ).to.equal(true)
-    })
-
-    it('.toString() outputs default base encoded CID', () => {
-      const mhStr = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
-      const cid = new CID(mhStr)
-      expect(`${cid}`).to.equal(mhStr)
-    })
-
-    it('.toString(base) outputs base encoded CID', () => {
-      const b58v1Str = 'zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS'
-      const b32v1Str = 'bafybeidskjjd4zmr7oh6ku6wp72vvbxyibcli2r6if3ocdcy7jjjusvl2u'
-      const cid = new CID(b58v1Str)
-      expect(cid.toString('base32')).to.equal(b32v1Str)
     })
   })
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -66,7 +66,19 @@ describe('CID', () => {
       ).to.throw()
     })
 
-    it('throws on trying to base encode CIDv0 in other base than base58 ', () => {
+    it('throws on trying to create a CIDv0 with a codec other than dag-pb', () => {
+      expect(
+        () => new CID(0, 'dag-cbor', hash)
+      ).to.throw(`codec must be 'dag-pb' for CIDv0`)
+    })
+
+    it('throws on trying to create a CIDv0 with a base other than base58btc', () => {
+      expect(
+        () => new CID(0, 'dag-pb', hash, 'base32')
+      ).to.throw(`multibaseName must be 'base58btc' for CIDv0`)
+    })
+
+    it('throws on trying to base encode CIDv0 in other base than base58btc', () => {
       const mhStr = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
       const cid = new CID(mhStr)
       expect(() => cid.toBaseEncodedString('base16')).to.throw()


### PR DESCRIPTION
BREAKING CHANGE - previously base was not preserved and all CIDs would
be normalised to base58btc when asked for their string representation.

The default will change to base32 in https://github.com/multiformats/js-cid/pull/73/files

The idea behind this change is that we shouldnt lose information when
the user passes us a base encoded string, but keep it and use it as
the default base so toString returns the same string they provided.

I'd like this as a fix for ipld explorer, which currently forces all
CIDs into base58btc, seee: https://github.com/ipfs-shipyard/ipfs-webui/issues/999

This PR is the smallest change I can see to make it work. Do we want
to also add base as a constructor parameter? If so, i guess it should
go at the end as it's optional, but thats aesthetically displeasing
as the base encoding goes at the front in string form.

fixes #76 

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>