### PR TITLE
feat: allow array-like objects as input

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -92,21 +92,22 @@ class CID {
       return
     }
 
-    if (Buffer.isBuffer(version)) {
-      const firstByte = version.slice(0, 1)
-      const v = parseInt(firstByte.toString('hex'), 16)
+    // It is an array-like object, e.g. Arraym, Buffer or TypedArray
+    if (version.length) {
+      // The first byte is the actual version
+      const v = version[0]
       if (v === 0 || v === 1) {
         // version is a CID buffer
         const cid = version
         this.version = v
         this.codec = multicodec.getCodec(cid.slice(1))
-        this.multihash = multicodec.rmPrefix(cid.slice(1))
+        this.multihash = Buffer.from(multicodec.rmPrefix(cid.slice(1)))
         this.multibaseName = (v === 0) ? 'base58btc' : multibaseName
       } else {
         // version is a raw multihash buffer, so v0
         this.version = 0
         this.codec = 'dag-pb'
-        this.multihash = version
+        this.multihash = Buffer.from(version)
         this.multibaseName = 'base58btc'
       }
       CID.validateCID(this)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -52,6 +52,40 @@ describe('CID', () => {
       })
     })
 
+    it('handles Uint8Array multihash', (done) => {
+      multihashing(Buffer.from('hello world'), 'sha2-256', (err, mh) => {
+        expect(err).to.not.exist()
+        const mhStr = 'QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4'
+        const mhUint8 = Uint8Array.from(mh)
+
+        const cid = new CID(mhUint8)
+
+        expect(cid).to.have.property('codec', 'dag-pb')
+        expect(cid).to.have.property('version', 0)
+        expect(cid).to.have.property('multihash').that.eql(mh)
+
+        expect(cid.toBaseEncodedString()).to.eql(mhStr)
+        done()
+      })
+    })
+
+    it('handles Array multihash', (done) => {
+      multihashing(Buffer.from('hello world'), 'sha2-256', (err, mh) => {
+        expect(err).to.not.exist()
+        const mhStr = 'QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4'
+        const mhArray = Uint8Array.from(mh)
+
+        const cid = new CID(mhArray)
+
+        expect(cid).to.have.property('codec', 'dag-pb')
+        expect(cid).to.have.property('version', 0)
+        expect(cid).to.have.property('multihash').that.eql(mh)
+
+        expect(cid.toBaseEncodedString()).to.eql(mhStr)
+        done()
+      })
+    })
+
     it('create by parts', () => {
       const cid = new CID(0, 'dag-pb', hash)
 
@@ -117,6 +151,34 @@ describe('CID', () => {
       const cidBuf = Buffer.from('017012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5', 'hex')
 
       const cid = new CID(cidBuf)
+
+      expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('version', 1)
+      expect(cid).to.have.property('multihash')
+
+      expect(cid.toBaseEncodedString()).to.be.eql(cidStr)
+    })
+
+    it('handles CID by Uint8Array', () => {
+      const cidStr = 'zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS'
+      const cidBuf = Buffer.from('017012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5', 'hex')
+      const cidUint8 = Uint8Array.from(cidBuf)
+
+      const cid = new CID(cidUint8)
+
+      expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('version', 1)
+      expect(cid).to.have.property('multihash')
+
+      expect(cid.toBaseEncodedString()).to.be.eql(cidStr)
+    })
+
+    it('handles CID by Array', () => {
+      const cidStr = 'zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS'
+      const cidBuf = Buffer.from('017012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5', 'hex')
+      const cidArray = Array.from(cidBuf)
+
+      const cid = new CID(cidArray)
 
       expect(cid).to.have.property('codec', 'dag-pb')
       expect(cid).to.have.property('version', 1)


### PR DESCRIPTION
Support not only Node.js Buffers, but also Uint8Arrays and normal
Arrays as input for CIDs.