### PR TITLE
feat: add flow typedefs

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,0 +1,32 @@
+// @flow strict
+
+export type Version = 0 | 1
+export type Codec = string
+export type Multihash = Buffer
+export type BaseEncodedString = string
+
+declare class CID<a> {
+  constructor(Version, Codec, Multihash): void;
+  constructor(BaseEncodedString): void;
+  constructor(Buffer): void;
+
+  +codec: Codec;
+  +multihash: Multihash;
+  +buffer: Buffer;
+  +prefix: Buffer;
+
+  toV0(): CID<a>;
+  toV1(): CID<a>;
+  toBaseEncodedString(base?: string): BaseEncodedString;
+  toString(): BaseEncodedString;
+  toJSON(): { codec: Codec, version: Version, hash: Multihash };
+
+  equals(mixed): boolean;
+
+  static codecs: { [string]: Codec };
+  static isCID(mixed): boolean;
+  static validateCID(mixed): void;
+}
+
+export default CID
+export type { CID }


### PR DESCRIPTION
Add flow type definitions which would improve workflow for dependent libraries that happen to use flow type-checker.

This just `index.js.flow` is what flow would resolve to when imported module resolves to `index.js` and there for dependencies of this library will be able to infer type info. 