### PR TITLE
fix: throw on toString when create new CID from old CID

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,13 +60,14 @@ class CID {
    * new CID(<cid>)
    */
   constructor (version, codec, multihash, multibaseName) {
-    if (module.exports.isCID(version)) {
+    if (_CID.isCID(version)) {
       // version is an exising CID instance
       const cid = version
       this.version = cid.version
       this.codec = cid.codec
       this.multihash = Buffer.from(cid.multihash)
-      this.multibaseName = cid.multibaseName
+      // Default guard for when a CID < 0.7 is passed with no multibaseName
+      this.multibaseName = cid.multibaseName || (cid.version === 0 ? 'base58btc' : 'base32')
       return
     }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -91,6 +91,18 @@ describe('CID', () => {
       const str = buffer.toString('hex')
       expect(str).to.equals('1220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
     })
+
+    it('should construct from an old CID without a multibaseName', () => {
+      const cidStr = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
+
+      const oldCid = new CID(cidStr)
+      delete oldCid.multibaseName // Fake it
+
+      const newCid = new CID(oldCid)
+
+      expect(newCid.multibaseName).to.equal('base58btc')
+      expect(newCid.toString()).to.equal(cidStr)
+    })
   })
 
   describe('v1', () => {
@@ -176,6 +188,18 @@ describe('CID', () => {
       }).to.throw(
         'Codec `this-codec-doesnt-exist` not found'
       )
+    })
+
+    it('should construct from an old CID without a multibaseName', () => {
+      const cidStr = 'bafybeidskjjd4zmr7oh6ku6wp72vvbxyibcli2r6if3ocdcy7jjjusvl2u'
+
+      const oldCid = new CID(cidStr)
+      delete oldCid.multibaseName // Fake it
+
+      const newCid = new CID(oldCid)
+
+      expect(newCid.multibaseName).to.equal('base32')
+      expect(newCid.toString()).to.equal(cidStr)
     })
   })
 


### PR DESCRIPTION
When creating a CID from another CID instance that was created by and old version of this module (< 0.7) the `multibaseName` property would become `undefined` and cause an error to be thrown when calling `toString`. This PR ensures an appropriate `multibaseName` is picked in the edge case that this happens.