### PR TITLE
fix: angular 8 -> braking change

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 const mh = require('multihashes')
 const multibase = require('multibase')
 const multicodec = require('multicodec')
-const codecs = require('multicodec/src/base-table')
+const codecs = require('multicodec/src/int-table')
 const CIDUtil = require('./cid-util')
 const withIs = require('class-is')
 


### PR DESCRIPTION
Fixing the braking change on Angular because of missing reference of `base-table`