### PR TITLE
feat: support Base36

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "buffer": "^5.5.0",
     "class-is": "^1.1.0",
-    "multibase": "~0.7.0",
+    "multibase": "^1.0.0",
     "multicodec": "^1.0.1",
     "multihashes": "~0.4.17"
   },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -133,6 +133,19 @@ describe('CID', () => {
       expect(cid.toBaseEncodedString()).to.be.eql(cidStr)
     })
 
+    it('handles ED25519 PeerID as CID in Base36', () => {
+      const peerIdStr = 'k51qzi5uqu5dj16qyiq0tajolkojyl9qdkr254920wxv7ghtuwcz593tp69z9m'
+
+      const cid = new CID(peerIdStr)
+
+      expect(cid).to.have.property('codec', 'libp2p-key')
+      expect(cid).to.have.property('version', 1)
+      expect(cid).to.have.property('multihash')
+      expect(cid).to.have.property('multibaseName', 'base36')
+
+      expect(cid.toBaseEncodedString()).to.be.eql(peerIdStr)
+    })
+
     it('create by parts', () => {
       const cid = new CID(1, 'dag-cbor', hash)
 


### PR DESCRIPTION
> Part of https://github.com/ipfs/go-ipfs/issues/7318

This PR:
- adds support for Base36
- adds test for ED25519 libp2p key represented as CIDv1 in Base36

@vmx the goal here is fix cid.ipfs.io (https://github.com/multiformats/cid-utils-website/issues/23) before go-ifps 0.6 is released. Are you able to merge this and release new version of `cids` to NPM?


