### PR TITLE
fix: replace node buffers with uint8arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# js-cid
+# js-cid  <!-- omit in toc -->
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai/)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
@@ -10,15 +10,34 @@
 
 > [CID](https://github.com/multiformats/cid) implementation in JavaScript.
 
-## Lead Maintainer
+## Lead Maintainer   <!-- omit in toc -->
 
 [Volker Mische](https://github.com/vmx)
 
-## Table of Contents
+## Table of Contents   <!-- omit in toc -->
 
 - [Install](#install)
+  - [In Node.js through npm](#in-nodejs-through-npm)
+  - [Browser: Browserify, Webpack, other bundlers](#browser-browserify-webpack-other-bundlers)
+  - [In the Browser through `<script>` tag](#in-the-browser-through-script-tag)
 - [Usage](#usage)
 - [API](#api)
+  - [CID.isCID(cid)](#cidiscidcid)
+  - [CID.validateCID(cid)](#cidvalidatecidcid)
+  - [new CID(version, codec, multihash, [multibaseName])](#new-cidversion-codec-multihash-multibasename)
+  - [new CID(baseEncodedString)](#new-cidbaseencodedstring)
+  - [new CID(Uint8Array)](#new-ciduint8array)
+    - [cid.codec](#cidcodec)
+    - [cid.version](#cidversion)
+    - [cid.multihash](#cidmultihash)
+    - [cid.multibaseName](#cidmultibasename)
+    - [cid.bytes](#cidbytes)
+    - [cid.prefix](#cidprefix)
+    - [cid.toV0()](#cidtov0)
+    - [cid.toV1()](#cidtov1)
+    - [cid.toBaseEncodedString(base=this.multibaseName)](#cidtobaseencodedstringbasethismultibasename)
+    - [cid.toString(base=this.multibaseName)](#cidtostringbasethismultibasename)
+    - [cid.equals(cid)](#cidequalscid)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -48,13 +67,9 @@ Loading this module through a script tag will make the ```Cids``` obj available 
 <script src="https://unpkg.com/cids/dist/index.js"></script>
 ```
 
-#### Gotchas
-
-You will need to use Node.js `Buffer` API compatible, if you are running inside the browser, you can access it by `multihash.Buffer` or you can install Feross's [Buffer](https://github.com/feross/buffer).
-
 ## Usage
 
-You can create an instance from a CID string or CID Buffer
+You can create an instance from a CID string or CID Uint8Array
 
 ```js
 const CID = require('cids')
@@ -73,8 +88,9 @@ or by specifying the [cid version](https://github.com/multiformats/cid#versions)
 ```js
 const CID = require('cids')
 const multihashing = require('multihashing-async')
+const bytes = new TextEncoder('utf8').encode('OMG!')
 
-const hash = await multihashing(Buffer.from('OMG!'), 'sha2-256')
+const hash = await multihashing(bytes, 'sha2-256')
 const cid = new CID(1, 'dag-pb', hash)
 console.log(cid.toString())
 // bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu
@@ -119,7 +135,7 @@ instance. Throws an `Error` if not valid.
 
 `codec` must be a string of a valid [registered codec](https://github.com/multiformats/multicodec/blob/master/table.csv).
 
-`multihash` must be a `Buffer` instance of a valid [multihash](https://github.com/multiformats/multihash).
+`multihash` must be a `Uint8Array` instance of a valid [multihash](https://github.com/multiformats/multihash).
 
 `multibaseName` optional string. Must be a valid [multibase](https://github.com/multiformats/multibase/blob/master/multibase.csv) name. Default is `base58btc` for v0 CIDs or `base32` for v1 CIDs.
 
@@ -128,9 +144,9 @@ instance. Throws an `Error` if not valid.
 Additionally, you can instantiate an instance from a base encoded
 string.
 
-### new CID(Buffer)
+### new CID(Uint8Array)
 
-Additionally, you can instantiate an instance from a buffer.
+Additionally, you can instantiate an instance from a `Uint8Array`.
 
 #### cid.codec
 
@@ -142,19 +158,19 @@ Property containing the CID version integer.
 
 #### cid.multihash
 
-Property containing the multihash buffer.
+Property containing the multihash `Uint8Array`.
 
 #### cid.multibaseName
 
 Property containing the default base to use when calling `.toString`
 
-#### cid.buffer
+#### cid.bytes
 
-Property containing the full CID encoded as a `Buffer`.
+Property containing the full CID encoded as a `Uint8Array`.
 
 #### cid.prefix
 
-Proprety containing a buffer of the CID version, codec, and the prefix
+Proprety containing a `Uint8Array` of the CID version, codec, and the prefix
 section of the multihash.
 
 #### cid.toV0()
@@ -174,7 +190,7 @@ Returns a base encoded string of the CID. Defaults to the base encoding in `this
 The value of `this.multibaseName` depends on how the instance was constructed:
 
 1. If the CID was constructed from an object that already had a multibase (a string or an existing CID) then it retains that base.
-2. If the CID was constructed from an object that _did not_ have a multibase (a buffer, or by passing only version + codec + multihash to the constructor), then `multibaseName` will be `base58btc` for a v0 CID or `base32` for a v1 CID.
+2. If the CID was constructed from an object that _did not_ have a multibase (a `Uint8Array`, or by passing only version + codec + multihash to the constructor), then `multibaseName` will be `base58btc` for a v0 CID or `base32` for a v1 CID.
 
 #### cid.toString(base=this.multibaseName)
 

--- a/package.json
+++ b/package.json
@@ -35,17 +35,15 @@
     "url": "https://github.com/multiformats/js-cid/issues"
   },
   "dependencies": {
-    "buffer": "^5.6.0",
     "class-is": "^1.1.0",
-    "multibase": "^1.0.0",
-    "multicodec": "^1.0.1",
-    "multihashes": "^1.0.1"
+    "multibase": "^3.0.0",
+    "multicodec": "^2.0.0",
+    "multihashes": "^3.0.1",
+    "uint8arrays": "^1.0.0"
   },
   "devDependencies": {
-    "aegir": "^23.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
-    "multihashing-async": "~0.8.1"
+    "aegir": "^25.0.0",
+    "multihashing-async": "^2.0.0"
   },
   "engines": {
     "node": ">=4.0.0",

--- a/src/cid-util.js
+++ b/src/cid-util.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const mh = require('multihashes')
-const { Buffer } = require('buffer')
-var CIDUtil = {
+
+const CIDUtil = {
   /**
    * Test if the given input is a valid CID object.
    * Returns an error message if it is not.
@@ -33,8 +33,8 @@ var CIDUtil = {
       }
     }
 
-    if (!Buffer.isBuffer(other.multihash)) {
-      return 'multihash must be a Buffer'
+    if (!(other.multihash instanceof Uint8Array)) {
+      return 'multihash must be a Uint8Array'
     }
 
     try {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,7 +13,7 @@ declare class CID {
    * else if (str)
    *   if (1st char is on multibase table) -> CID String
    *   else -> bs58 encoded multihash
-   * else if (Buffer)
+   * else if (Uint8Array)
    *   if (1st byte is 0 or 1) -> CID
    *   else -> multihash
    * else if (Number)
@@ -23,7 +23,7 @@ declare class CID {
    * @example
    * new CID(<version>, <codec>, <multihash>, <multibaseName>)
    * new CID(<cidStr>)
-   * new CID(<cid.buffer>)
+   * new CID(<cid.bytes>)
    * new CID(<multihash>)
    * new CID(<bs58 encoded multihash>)
    * new CID(<cid>)
@@ -31,12 +31,12 @@ declare class CID {
   constructor(
     version: 0 | 1,
     codec: string,
-    multhash: Buffer,
+    multhash: Uint8Array,
     multibaseName?: string
   );
   constructor(cid: CID);
   constructor(str: string);
-  constructor(buf: Buffer);
+  constructor(buf: Uint8Array);
 
   /**
    * The version of the CID.
@@ -51,7 +51,7 @@ declare class CID {
   /**
    * The multihash of the CID.
    */
-  multihash: Buffer;
+  multihash: Uint8Array;
 
   /**
    * Multibase name as string.
@@ -59,14 +59,14 @@ declare class CID {
   multibaseName: string;
 
   /**
-   * The CID as a `Buffer`
+   * The CID as a `Uint8Array`
    */
-  readonly buffer: Buffer;
+  readonly bytes: Uint8Array;
 
   /**
    * The prefix of the CID.
    */
-  readonly prefix: Buffer;
+  readonly prefix: Uint8Array;
 
   /**
    * Convert to a CID of version `0`.
@@ -93,7 +93,7 @@ declare class CID {
   /**
    * Serialize to a plain object.
    */
-  toJSON(): { codec: string; version: 0 | 1; hash: Buffer };
+  toJSON(): { codec: string; version: 0 | 1; hash: Uint8Array };
 
   /**
    * Compare equality with another CID.

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const CIDUtil = require('./cid-util')
 const withIs = require('class-is')
 const uint8ArrayConcat = require('uint8arrays/concat')
 const uint8ArrayToString = require('uint8arrays/to-string')
+const uint8ArrayEquals = require('uint8arrays/equals')
 
 /**
  * @typedef {Object} SerializedCID
@@ -282,7 +283,7 @@ class CID {
   equals (other) {
     return this.codec === other.codec &&
       this.version === other.version &&
-      this.multihash.equals(other.multihash)
+      uint8ArrayEquals(this.multihash, other.multihash)
   }
 
   /**

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -2,19 +2,19 @@
 
 export type Version = 0 | 1
 export type Codec = string
-export type Multihash = Buffer
+export type Multihash = Uint8Array
 export type BaseEncodedString = string
 export type MultibaseName = string
 
 declare class CID<a> {
   constructor(Version, Codec, Multihash, multibaseName?:MultibaseName): void;
   constructor(BaseEncodedString): void;
-  constructor(Buffer): void;
+  constructor(Uint8Array): void;
 
   +codec: Codec;
   +multihash: Multihash;
-  +buffer: Buffer;
-  +prefix: Buffer;
+  +bytes: Uint8Array;
+  +prefix: Uint8Array;
 
   toV0(): CID<a>;
   toV1(): CID<a>;

--- a/test/cid-util.spec.js
+++ b/test/cid-util.spec.js
@@ -2,20 +2,17 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multihashing = require('multihashing-async')
 const CID = require('../src')
 const CIDUtil = require('../src/cid-util')
-const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('CIDUtil', () => {
   let hash
 
   before(async () => {
-    hash = await multihashing(Buffer.from('abc'), 'sha2-256')
+    hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
   })
 
   describe('checkCIDComponents()', () => {
@@ -41,25 +38,25 @@ describe('CIDUtil', () => {
       const invalid = [
         'hello world',
         'QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L',
-        Buffer.from('hello world'),
-        Buffer.from('QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT')
+        uint8ArrayFromString('hello world'),
+        uint8ArrayFromString('QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT')
       ]
 
-      invalid.forEach((i) => it(`new CID(${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`, () => {
+      invalid.forEach((i) => it(`new CID(${i instanceof Uint8Array ? 'Uint8Array' : 'String'}<${i.toString()}>)`, () => {
         expect(() => {
           const errMsg = CIDUtil.checkCIDComponents(i)
           expect(errMsg).to.exist()
         }).to.not.throw()
       }))
 
-      invalid.forEach((i) => it(`new CID(0, 'dag-pb', ${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`, () => {
+      invalid.forEach((i) => it(`new CID(0, 'dag-pb', ${i instanceof Uint8Array ? 'Uint8Array' : 'String'}<${i.toString()}>)`, () => {
         expect(() => {
           const errMsg = CIDUtil.checkCIDComponents(0, 'dag-pb', i)
           expect(errMsg).to.exist()
         }).to.not.throw()
       }))
 
-      invalid.forEach((i) => it(`new CID(1, 'dag-pb', ${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`, () => {
+      invalid.forEach((i) => it(`new CID(1, 'dag-pb', ${i instanceof Uint8Array ? 'Uint8Array' : 'String'}<${i.toString()}>)`, () => {
         expect(() => {
           const errMsg = CIDUtil.checkCIDComponents(1, 'dag-pb', i)
           expect(errMsg).to.exist()

--- a/test/helpers/gen-cid.js
+++ b/test/helpers/gen-cid.js
@@ -6,16 +6,16 @@
 const multibase = require('multibase')
 const codecs = require('../../src').codecs
 const multihashing = require('multihashing-async')
-const { Buffer } = require('buffer')
+const utf8ArrayFromString = require('uint8arrays/from-string')
 
 async function main () {
-  const mh = await multihashing(Buffer.from('oh, hey!'), 'sha2-256')
+  const mh = await multihashing(utf8ArrayFromString('oh, hey!'), 'sha2-256')
 
-  const cid = Buffer.concat([
-    Buffer.from('01', 'hex'),
-    Buffer.from([codecs['dag-pb']]),
-    mh
-  ])
+  const cid = Uint8Array.of(
+    1,
+    codecs['dag-pb'],
+    ...mh
+  )
 
   const cidStr = multibase.encode('base58btc', cid).toString()
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -276,6 +276,15 @@ describe('CID', () => {
       expect(cidV1.multihash).to.eql(cidV0.multihash)
     })
 
+    it('.equals a similar CID with a Uint8Array multihash', () => {
+      const str = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
+      const cid = new CID(str)
+      const cidA = new CID(cid.version, cid.codec, Uint8Array.from(cid.multihash))
+      const cidB = new CID(str)
+
+      expect(cidA.equals(cidB)).to.equal(true)
+    })
+
     it('.isCid', () => {
       expect(
         CID.isCID(new CID(h1))

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,21 +2,18 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
+const { expect } = require('aegir/utils/chai')
 const multihash = require('multihashes')
 const multihashing = require('multihashing-async')
-const { Buffer } = require('buffer')
-
+const uint8ArrayFromString = require('uint8arrays/from-string')
+const uint8ArrayToString = require('uint8arrays/to-string')
 const CID = require('../src')
 
 describe('CID', () => {
   let hash
 
   before(async () => {
-    hash = await multihashing(Buffer.from('abc'), 'sha2-256')
+    hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
   })
 
   describe('v0', () => {
@@ -32,8 +29,8 @@ describe('CID', () => {
       expect(cid.toBaseEncodedString()).to.be.eql(mhStr)
     })
 
-    it('handles Buffer multihash', async () => {
-      const mh = await multihashing(Buffer.from('hello world'), 'sha2-256')
+    it('handles Uint8Array multihash', async () => {
+      const mh = await multihashing(uint8ArrayFromString('hello world'), 'sha2-256')
       const mhStr = 'QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L4'
 
       const cid = new CID(mh)
@@ -81,15 +78,15 @@ describe('CID', () => {
 
     it('.prefix', () => {
       const cid = new CID(0, 'dag-pb', hash)
-      expect(cid.prefix.toString('hex')).to.equal('00701220')
+      expect(uint8ArrayToString(cid.prefix, 'base16')).to.equal('00701220')
     })
 
-    it('.buffer', () => {
+    it('.bytes', () => {
       const codec = 'dag-pb'
       const cid = new CID(0, codec, hash)
-      const buffer = cid.buffer
-      expect(buffer).to.exist()
-      const str = buffer.toString('hex')
+      const bytes = cid.bytes
+      expect(bytes).to.exist()
+      const str = uint8ArrayToString(bytes, 'base16')
       expect(str).to.equals('1220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
     })
 
@@ -122,7 +119,7 @@ describe('CID', () => {
 
     it('handles CID (no multibase)', () => {
       const cidStr = 'bafybeidskjjd4zmr7oh6ku6wp72vvbxyibcli2r6if3ocdcy7jjjusvl2u'
-      const cidBuf = Buffer.from('017012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5', 'hex')
+      const cidBuf = uint8ArrayFromString('017012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5', 'base16')
 
       const cid = new CID(cidBuf)
 
@@ -167,7 +164,7 @@ describe('CID', () => {
     })
 
     it('handles multibyte varint encoded codec codes', () => {
-      const ethBlockHash = Buffer.from('8a8e84c797605fbe75d5b5af107d4220a2db0ad35fd66d9be3d38d87c472b26d', 'hex')
+      const ethBlockHash = uint8ArrayFromString('8a8e84c797605fbe75d5b5af107d4220a2db0ad35fd66d9be3d38d87c472b26d', 'base16')
       const mh = multihash.encode(ethBlockHash, 'keccak-256')
       const cid1 = new CID(1, 'eth-block', mh)
       const cid2 = new CID(cid1.toBaseEncodedString())
@@ -184,11 +181,11 @@ describe('CID', () => {
 
     it('.prefix', () => {
       const cid = new CID(1, 'dag-cbor', hash)
-      expect(cid.prefix.toString('hex')).to.equal('01711220')
+      expect(uint8ArrayToString(cid.prefix, 'base16')).to.equal('01711220')
     })
 
     it('.prefix identity multihash', () => {
-      const mh = multihash.encode(Buffer.from('abc'), 'identity')
+      const mh = multihash.encode(uint8ArrayFromString('abc'), 'identity')
       const cid0 = new CID(0, 'dag-pb', mh)
 
       expect(cid0).to.have.property('codec', 'dag-pb')
@@ -204,12 +201,12 @@ describe('CID', () => {
       expect(cid1.toBaseEncodedString()).to.eql('bafyqaa3bmjrq')
     })
 
-    it('.buffer', () => {
+    it('.bytes', () => {
       const codec = 'dag-cbor' // Invalid codec will cause an error: Issue #46
       const cid = new CID(1, codec, hash)
-      const buffer = cid.buffer
-      expect(buffer).to.exist()
-      const str = buffer.toString('hex')
+      const bytes = cid.bytes
+      expect(bytes).to.exist()
+      const str = uint8ArrayToString(bytes, 'base16')
       expect(str).to.equals('01711220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
     })
 
@@ -289,7 +286,7 @@ describe('CID', () => {
       ).to.equal(false)
 
       expect(
-        CID.isCID(Buffer.from('hello world'))
+        CID.isCID(uint8ArrayFromString('hello world'))
       ).to.equal(false)
 
       expect(
@@ -306,24 +303,24 @@ describe('CID', () => {
     const invalid = [
       'hello world',
       'QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L',
-      Buffer.from('hello world'),
-      Buffer.from('QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT')
+      uint8ArrayFromString('hello world'),
+      uint8ArrayFromString('QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT')
     ]
 
-    invalid.forEach((i) => it(`new CID(${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`, () => {
+    invalid.forEach((i) => it(`new CID(${i instanceof Uint8Array ? 'Uint8Array' : 'String'}<${i.toString()}>)`, () => {
       expect(() => new CID(i)).to.throw()
     }))
 
-    invalid.forEach((i) => it(`new CID(0, 'dag-pb', ${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`, () => {
+    invalid.forEach((i) => it(`new CID(0, 'dag-pb', ${i instanceof Uint8Array ? 'Uint8Array' : 'String'}<${i.toString()}>)`, () => {
       expect(() => new CID(0, 'dag-pb', i)).to.throw()
     }))
 
-    invalid.forEach((i) => it(`new CID(1, 'dag-pb', ${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`, () => {
+    invalid.forEach((i) => it(`new CID(1, 'dag-pb', ${i instanceof Uint8Array ? 'Uint8Array' : 'String'}<${i.toString()}>)`, () => {
       expect(() => new CID(1, 'dag-pb', i)).to.throw()
     }))
 
     const invalidVersions = [-1, 2]
-    invalidVersions.forEach((i) => it(`new CID(${i}, 'dag-pb', buffer)`, () => {
+    invalidVersions.forEach((i) => it(`new CID(${i}, 'dag-pb', bytes)`, () => {
       expect(() => new CID(i, 'dag-pb', hash)).to.throw()
     }))
   })
@@ -341,44 +338,44 @@ describe('CID', () => {
 
   describe('conversion v0 <-> v1', () => {
     it('should convert v0 to v1', async () => {
-      const hash = await multihashing(Buffer.from(`TEST${Date.now()}`), 'sha2-256')
+      const hash = await multihashing(uint8ArrayFromString(`TEST${Date.now()}`), 'sha2-256')
       const cid = new CID(0, 'dag-pb', hash).toV1()
       expect(cid.version).to.equal(1)
     })
 
     it('should convert v1 to v0', async () => {
-      const hash = await multihashing(Buffer.from(`TEST${Date.now()}`), 'sha2-256')
+      const hash = await multihashing(uint8ArrayFromString(`TEST${Date.now()}`), 'sha2-256')
       const cid = new CID(1, 'dag-pb', hash).toV0()
       expect(cid.version).to.equal(0)
     })
 
     it('should not convert v1 to v0 if not dag-pb codec', async () => {
-      const hash = await multihashing(Buffer.from(`TEST${Date.now()}`), 'sha2-256')
+      const hash = await multihashing(uint8ArrayFromString(`TEST${Date.now()}`), 'sha2-256')
       const cid = new CID(1, 'dag-cbor', hash)
       expect(() => cid.toV0()).to.throw('Cannot convert a non dag-pb CID to CIDv0')
     })
 
     it('should not convert v1 to v0 if not sha2-256 multihash', async () => {
-      const hash = await multihashing(Buffer.from(`TEST${Date.now()}`), 'sha2-512')
+      const hash = await multihashing(uint8ArrayFromString(`TEST${Date.now()}`), 'sha2-512')
       const cid = new CID(1, 'dag-pb', hash)
       expect(() => cid.toV0()).to.throw('Cannot convert non sha2-256 multihash CID to CIDv0')
     })
 
     it('should not convert v1 to v0 if not 32 byte multihash', async () => {
-      const hash = await multihashing(Buffer.from(`TEST${Date.now()}`), 'sha2-256', 31)
+      const hash = await multihashing(uint8ArrayFromString(`TEST${Date.now()}`), 'sha2-256', 31)
       const cid = new CID(1, 'dag-pb', hash)
       expect(() => cid.toV0()).to.throw('Cannot convert non 32 byte multihash CID to CIDv0')
     })
   })
 
   describe('caching', () => {
-    it('should cache CID as buffer', async () => {
-      const hash = await multihashing(Buffer.from(`TEST${Date.now()}`), 'sha2-256')
+    it('should cache CID as bytes', async () => {
+      const hash = await multihashing(uint8ArrayFromString(`TEST${Date.now()}`), 'sha2-256')
       const cid = new CID(1, 'dag-pb', hash)
-      expect(cid.buffer).to.equal(cid.buffer)
+      expect(cid.bytes).to.equal(cid.bytes)
       // Make sure custom implementation detail properties don't leak into
       // the prototype
-      expect(Object.prototype.hasOwnProperty.call(cid, 'buffer')).to.be.false()
+      expect(Object.prototype.hasOwnProperty.call(cid, 'bytes')).to.be.false()
     })
     it('should cache string representation when it matches the multibaseName it was constructed with', () => {
       // not string to cache yet

--- a/test/profiling/cidperf-x.js
+++ b/test/profiling/cidperf-x.js
@@ -6,6 +6,7 @@ const multihashing = require('multihashing-async')
 // const CID = require('cids')
 // [2] New/proposed implementation.
 const CID = require('../../src')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 
 // Used to delay the testing for a few seconds.
 function sleep (ms) {
@@ -47,7 +48,7 @@ sleep(1000).then(async () => {
   console.log('Starting a test...')
   console.time('run')
 
-  const mh = await multihashing(Buffer.from('oh, hey!'), 'sha2-256')
+  const mh = await multihashing(uint8ArrayFromString('oh, hey!'), 'sha2-256')
   const cidPerf = new CIDPerfX(mh);
 
   [...Array(reps).keys()].map(i => {


### PR DESCRIPTION
Relaxes input from requiring node `Buffer`s to being `Uint8Arrays`.

This also means that the `.buffer` (now `.byte`) and `.prefix` properties have changed to be `Uint8Array`s.

Depends on:

- [x] https://github.com/multiformats/js-multicodec/pull/63
- [x] https://github.com/multiformats/js-multihashing-async/pull/78
- [x] https://github.com/multiformats/js-multihash/pull/92

BREAKING CHANGES:

- node `Buffer`s have been replaced with `Uint8Array`s
- the `.buffer` property has been renamed to `.bytes` and is now a `Uint8Array`
- the `.prefix` property is now a `Uint8Array`