### PR TITLE
feat: expose codec code and allow construction by code

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
   - [new CID(baseEncodedString)](#new-cidbaseencodedstring)
   - [new CID(Uint8Array)](#new-ciduint8array)
     - [cid.codec](#cidcodec)
+    - [cid.code](#cidcode)
     - [cid.version](#cidversion)
     - [cid.multihash](#cidmultihash)
     - [cid.multibaseName](#cidmultibasename)
@@ -78,6 +79,7 @@ const cid = new CID('bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu
 
 cid.version       // 1
 cid.codec         // 'dag-pb'
+cid.code          // 112
 cid.multibaseName // 'base32'
 cid.toString()
 // 'bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu'
@@ -92,6 +94,14 @@ const bytes = new TextEncoder('utf8').encode('OMG!')
 
 const hash = await multihashing(bytes, 'sha2-256')
 const cid = new CID(1, 'dag-pb', hash)
+console.log(cid.toString())
+// bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu
+```
+
+The multicodec integer code can also be used to create a new CID:
+
+```js
+const cid = new CID(1, 112, hash)
 console.log(cid.toString())
 // bafybeig6xv5nwphfmvcnektpnojts33jqcuam7bmye2pb54adnrtccjlsu
 ```
@@ -150,7 +160,11 @@ Additionally, you can instantiate an instance from a `Uint8Array`.
 
 #### cid.codec
 
-Property containing the codec string.
+Property containing the string identifier of the codec.
+
+#### cid.code
+
+Property containing the integer identifier of the codec.
 
 #### cid.version
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -30,7 +30,7 @@ declare class CID {
    */
   constructor(
     version: 0 | 1,
-    codec: string,
+    codec: string | number,
     multhash: Uint8Array,
     multibaseName?: string
   );
@@ -47,6 +47,11 @@ declare class CID {
    * The codec of the CID.
    */
   codec: string;
+
+  /**
+   * The codec of the CID in its number form.
+   */
+  code: number;
 
   /**
    * The multihash of the CID.

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,11 @@ const uint8ArrayConcat = require('uint8arrays/concat')
 const uint8ArrayToString = require('uint8arrays/to-string')
 const uint8ArrayEquals = require('uint8arrays/equals')
 
+const codecInts = Object.keys(codecs).reduce((p, name) => {
+  p[codecs[name]] = name
+  return p
+}, {})
+
 /**
  * @typedef {Object} SerializedCID
  * @param {string} codec
@@ -50,7 +55,7 @@ class CID {
    * ```
    *
    * @param {string|Uint8Array|CID} version
-   * @param {string} [codec]
+   * @param {string|number} [codec]
    * @param {Uint8Array} [multihash]
    * @param {string} [multibaseName]
    *
@@ -124,6 +129,10 @@ class CID {
      */
     this.version = version
 
+    if (typeof codec === 'number') {
+      codec = codecInts[codec]
+    }
+
     /**
      * @type {string}
      */
@@ -186,6 +195,10 @@ class CID {
     ], 1 + codec.byteLength + multihash.byteLength)
 
     return prefix
+  }
+
+  get code () {
+    return codecs[this.codec]
   }
 
   /**

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -2,16 +2,19 @@
 
 export type Version = 0 | 1
 export type Codec = string
+export type CodecCode = number
 export type Multihash = Uint8Array
 export type BaseEncodedString = string
 export type MultibaseName = string
 
 declare class CID<a> {
   constructor(Version, Codec, Multihash, multibaseName?:MultibaseName): void;
+  constructor(Version, CodecCode, Multihash, multibaseName?:MultibaseName): void;
   constructor(BaseEncodedString): void;
   constructor(Uint8Array): void;
 
   +codec: Codec;
+  +code: CodecCode;
   +multihash: Multihash;
   +bytes: Uint8Array;
   +prefix: Uint8Array;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -22,6 +22,7 @@ describe('CID', () => {
       const cid = new CID(mhStr)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', 112)
       expect(cid).to.have.property('version', 0)
       expect(cid).to.have.property('multihash').that.eql(multihash.fromB58String(mhStr))
       expect(cid).to.have.property('multibaseName', 'base58btc')
@@ -36,6 +37,7 @@ describe('CID', () => {
       const cid = new CID(mh)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', 112)
       expect(cid).to.have.property('version', 0)
       expect(cid).to.have.property('multihash').that.eql(mh)
       expect(cid).to.have.property('multibaseName', 'base58btc')
@@ -47,6 +49,17 @@ describe('CID', () => {
       const cid = new CID(0, 'dag-pb', hash)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', 112)
+      expect(cid).to.have.property('version', 0)
+      expect(cid).to.have.property('multihash')
+      expect(cid).to.have.property('multibaseName', 'base58btc')
+    })
+
+    it('create by parts (int codec)', () => {
+      const cid = new CID(0, 112, hash)
+
+      expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', 112)
       expect(cid).to.have.property('version', 0)
       expect(cid).to.have.property('multihash')
       expect(cid).to.have.property('multibaseName', 'base58btc')
@@ -110,6 +123,7 @@ describe('CID', () => {
       const cid = new CID(cidStr)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', 112)
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
       expect(cid).to.have.property('multibaseName', 'base58btc')
@@ -124,6 +138,7 @@ describe('CID', () => {
       const cid = new CID(cidBuf)
 
       expect(cid).to.have.property('codec', 'dag-pb')
+      expect(cid).to.have.property('code', 112)
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
       expect(cid).to.have.property('multibaseName', 'base32')
@@ -137,6 +152,7 @@ describe('CID', () => {
       const cid = new CID(peerIdStr)
 
       expect(cid).to.have.property('codec', 'libp2p-key')
+      expect(cid).to.have.property('code', 114)
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
       expect(cid).to.have.property('multibaseName', 'base36')
@@ -148,6 +164,7 @@ describe('CID', () => {
       const cid = new CID(1, 'dag-cbor', hash)
 
       expect(cid).to.have.property('codec', 'dag-cbor')
+      expect(cid).to.have.property('code', 113)
       expect(cid).to.have.property('version', 1)
       expect(cid).to.have.property('multihash')
       expect(cid).to.have.property('multibaseName', 'base32')
@@ -158,6 +175,7 @@ describe('CID', () => {
       const cid2 = new CID(cid1.toBaseEncodedString())
 
       expect(cid1).to.have.property('codec').that.eql(cid2.codec)
+      expect(cid1).to.have.property('code').that.eql(cid2.code)
       expect(cid1).to.have.property('version').that.eql(cid2.version)
       expect(cid1).to.have.property('multihash').that.eql(cid2.multihash)
       expect(cid1).to.have.property('multibaseName').that.eql(cid2.multibaseName)
@@ -170,6 +188,7 @@ describe('CID', () => {
       const cid2 = new CID(cid1.toBaseEncodedString())
 
       expect(cid1).to.have.property('codec', 'eth-block')
+      expect(cid1).to.have.property('code', 144)
       expect(cid1).to.have.property('version', 1)
       expect(cid1).to.have.property('multihash').that.eql(mh)
       expect(cid1).to.have.property('multibaseName', 'base32')
@@ -189,6 +208,7 @@ describe('CID', () => {
       const cid0 = new CID(0, 'dag-pb', mh)
 
       expect(cid0).to.have.property('codec', 'dag-pb')
+      expect(cid0).to.have.property('code', 112)
       expect(cid0).to.have.property('version', 0)
       expect(cid0).to.have.property('multihash').that.eql(mh)
       expect(cid0.toBaseEncodedString()).to.eql('161g3c')
@@ -196,6 +216,7 @@ describe('CID', () => {
       const cid1 = new CID(1, 'dag-cbor', mh)
 
       expect(cid1).to.have.property('codec', 'dag-cbor')
+      expect(cid1).to.have.property('code', 113)
       expect(cid1).to.have.property('version', 1)
       expect(cid1).to.have.property('multihash').that.eql(mh)
       expect(cid1.toBaseEncodedString()).to.eql('bafyqaa3bmjrq')


### PR DESCRIPTION
(this PR assumes #117, review should focus only on the HEAD commit please, c043bc5)

Ref: https://github.com/multiformats/js-cid/pull/117#issuecomment-668131658

The idea here is that js-multiformats is going to require a switch to using the multicodec integer code rather than string, which does away with the need to bundle the entire multicodec table (and if you want string and you're happy to have the table then that's fine but you get to choose that). Experience shows that this is the most painful compatibility problem when switching between this library and `multiformats.CID` (and vice versa). Having a constructor that can take (optionally) an integer code rather than a string makes it the same constructor as `multiformats.CID` and exposing the `code` property makes it the same interface. So we can write new code that works against `CID` and `multiformats.CID` without having to worry too much. The `asCID()` will be icing on the cake too.

As long as we're getting an awkward breaking change into the code, we may as well make sure that anyone who has that code _also_ has this and there's not an in-between state where there's breaking code and then there's this feature out there and you may have one and not the other. Basically it'd be nice to have this out in the wild ASAP to ease future transition and the current breaking change release seems like a good mechanism to force that.