### PR TITLE
fix: never return Node.js Buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,14 @@
   },
   "dependencies": {
     "class-is": "^1.1.0",
-    "multibase": "^3.0.0",
-    "multicodec": "^2.0.0",
+    "multibase": "^3.0.1",
+    "multicodec": "^2.0.1",
     "multihashes": "^3.0.1",
-    "uint8arrays": "^1.0.0"
+    "uint8arrays": "^1.1.0"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
-    "multihashing-async": "^2.0.0"
+    "aegir": "^26.0.0",
+    "multihashing-async": "^2.0.1"
   },
   "engines": {
     "node": ">=4.0.0",


### PR DESCRIPTION
With updating the dependencies, we now never return Node.js Buffers

There were cases where CIDs where returned as Node.js Buffers. Now all
CIDs are returned as Uint8Array only.

Fixes #126.