### PR TITLE
fix: relax version type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,7 +29,7 @@ declare class CID {
    * new CID(<cid>)
    */
   constructor(
-    version: 0 | 1,
+    version: number,
     codec: string | number,
     multhash: Uint8Array,
     multibaseName?: string


### PR DESCRIPTION
We use the TS typing to enforce only `0` or `1` as version numbers, but mark the `version` property of a CID as `number` which means it can be any value.

Here we relax the version number input to be the same as the `version` property which means:

a) we aren't using types for data validation any more (please let's not do this)
b) we can pass `cid.version` in to other functions without needing to do weird type contortions to account for it only being `0|1`
c) we can handle CIDv2 if/when that comes along