### PR TITLE
fix: pin multicodec to version 2.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "multibase": "^3.0.1",
-    "multicodec": "^2.0.1",
+    "multicodec": "=2.0.4",
     "multihashes": "^3.0.1",
     "uint8arrays": "^1.1.0"
   },


### PR DESCRIPTION
The 2.1.0 breaks this module as we are using a non-public export that
is no longer available.