### PR TITLE
fix: turn isCID to a type guard

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -334,7 +334,7 @@ class CID {
    * Check if object is a CID instance
    *
    * @param {any} value
-   * @returns {boolean}
+   * @returns {value is CID}
    */
   static isCID (value) {
     return value instanceof CID || Boolean(value && value[symbol])


### PR DESCRIPTION
This fixes regression caused by switch to generated typedefs which turned `isCID` to non type guard predicate.
For details on type guards see: https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards