### PR TITLE
fix: use latest multicodec release

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "release-minor": "aegir release --type minor --docs",
     "release-major": "aegir release --type major --docs",
     "coverage": "aegir coverage",
-    "docs": "aegir docs"
+    "docs": "aegir docs",
+    "prepare": "aegir ts -p types"
   },
   "files": [
     "src",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "multibase": "^3.0.1",
-    "multicodec": "=2.0.4",
+    "multicodec": "^2.1.0",
     "multihashes": "^3.0.1",
     "uint8arrays": "^1.1.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 const mh = require('multihashes')
 const multibase = require('multibase')
 const multicodec = require('multicodec')
-const codecs = require('multicodec/src/base-table.json')
+const { baseTable: codecs } = require('multicodec/src/base-table.js')
 const CIDUtil = require('./cid-util')
 const uint8ArrayConcat = require('uint8arrays/concat')
 const uint8ArrayToString = require('uint8arrays/to-string')


### PR DESCRIPTION
Using internal modules is a bad idea, but this is a quick fix in order
to not break the world.