### PR TITLE
fix: typing mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "CID Implementation in JavaScript",
   "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
-  "types": "src/index.d.ts",
+  "types": "dist/src/index.d.ts",
+  "typesVersions": {
+    "*": { "src/*": ["dist/src/*", "dist/src/*/index"] }
+  },
   "scripts": {
     "lint": "aegir lint",
     "test": "aegir test",


### PR DESCRIPTION
Fixes regression introduced by #131 due to incorrect type mappings.

P.S.: It was not caught by js-ipfs because import end up having `any` type 