### PR TITLE
fix: types to align with multicodec api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,8 @@ const symbol = Symbol.for('@ipld/js-cid/CID')
 /**
  * @typedef {0|1} CIDVersion
  * @typedef {import('multibase').BaseNameOrCode} BaseNameOrCode
+ * @typedef {import('multicodec').CodecName} CodecName
+ * @typedef {import('multicodec').CodecNumber} CodecNumber
  */
 
 /**
@@ -65,6 +67,34 @@ class CID {
    * new CID(<cid>)
    */
   constructor (version, codec, multihash, multibaseName) {
+    // We have below three blank field accessors only because
+    // otherwise TS will not pick them up if done after assignemnts
+
+    /**
+     * The version of the CID.
+     *
+     * @type {CIDVersion}
+     */
+    // eslint-disable-next-line no-unused-expressions
+    this.version
+
+    /**
+     * The codec of the CID.
+     *
+     * @deprecated
+     * @type {CodecName}
+     */
+    // eslint-disable-next-line no-unused-expressions
+    this.codec
+
+    /**
+     * The multihash of the CID.
+     *
+     * @type {Uint8Array}
+     */
+    // eslint-disable-next-line no-unused-expressions
+    this.multihash
+
     Object.defineProperty(this, symbol, { value: true })
     if (CID.isCID(version)) {
       // version is an exising CID instance
@@ -83,7 +113,7 @@ class CID {
       if (baseName) {
         // version is a CID String encoded with multibase, so v1
         const cid = multibase.decode(version)
-        this.version = parseInt(cid[0].toString(), 16)
+        this.version = /** @type {CIDVersion} */(parseInt(cid[0].toString(), 16))
         this.codec = multicodec.getCodec(cid.slice(1))
         this.multihash = multicodec.rmPrefix(cid.slice(1))
         this.multibaseName = baseName
@@ -121,30 +151,15 @@ class CID {
 
     // otherwise, assemble the CID from the parameters
 
-    /**
-     * The version of the CID.
-     *
-     * @type {CIDVersion}
-     */
     this.version = version
 
     if (typeof codec === 'number') {
       codec = codecInts[codec]
     }
 
-    /**
-     * The codec of the CID.
-     *
-     * @type {string}
-     */
-    this.codec = codec
+    this.codec = /** @type {CodecName} */ (codec)
 
-    /**
-     * The multihash of the CID.
-     *
-     * @type {Uint8Array}
-     */
-    this.multihash = multihash
+    this.multihash = /** @type {Uint8Array} */ (multihash)
 
     /**
      * Multibase name as string.
@@ -204,7 +219,7 @@ class CID {
   /**
    * The codec of the CID in its number form.
    *
-   * @returns {number}
+   * @returns {CodecNumber}
    */
   get code () {
     return codecs[this.codec]

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,6 +5,7 @@
 const { expect } = require('aegir/utils/chai')
 const multihash = require('multihashes')
 const multihashing = require('multihashing-async')
+const multicodec = require('multicodec')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 const uint8ArrayToString = require('uint8arrays/to-string')
 const CID = require('../src')
@@ -490,6 +491,18 @@ describe('CID', () => {
       cid3.bytes // eslint-disable-line no-unused-expressions
 
       expect(deepEqual(cid2, cid3)).to.be.true()
+    })
+  })
+
+  describe('multicodec', () => {
+    it('should have .code compatible with multicodec.getName', () => {
+      const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
+      expect(multicodec.getName(cid.code)).equal('dag-pb')
+    })
+
+    it('should have .codec compatible with multicodec.getCode', () => {
+      const cid = new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n')
+      expect(multicodec.getNumber(cid.codec)).equal(cid.code)
     })
   })
 })


### PR DESCRIPTION
Added types in multicodec introduces issue in js-ipfs [when using `multicodec.getName(cid.code)`](https://github.com/ipfs/js-ipfs/blob/eceb0d4fc313f8b8c763f508c0fab25eaa91c10a/packages/ipfs-http-client/src/dag/put.js#L31) because `cid.code` was entyped as number while `getName` expects `CodecNumber` that is subset of number.

This change addresses that issue by changing `code` type accordingly & updating `codec` type to also fix  `multicodec.getNumber(cid.codec)`.

I also have noticed that generated types had bunch fields `version`, `codec` and `multihash` types generated as `any`, that is because constructor has early returns so type annotations at the end of the constructor were ignored. This pull fixes that by moving those annotations at the top of the file instead.