### PR TITLE
fix: fix types and remove typesVersions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,14 +5,6 @@
   "leadMaintainer": "Volker Mische <volker.mische@gmail.com>",
   "main": "src/index.js",
   "types": "dist/src/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "src/*": [
-        "dist/src/*",
-        "dist/src/*/index"
-      ]
-    }
-  },
   "scripts": {
     "lint": "aegir lint",
     "test": "aegir test",
@@ -50,12 +42,12 @@
   "dependencies": {
     "multibase": "^3.0.1",
     "multicodec": "^2.1.0",
-    "multihashes": "^3.0.1",
-    "uint8arrays": "^1.1.0"
+    "multihashes": "^3.1.0",
+    "uint8arrays": "^2.0.5"
   },
   "devDependencies": {
     "@sinonjs/samsam": "^5.3.0",
-    "aegir": "^29.0.1",
+    "aegir": "^30.3.0",
     "multihashing-async": "^2.0.1"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,10 @@ const uint8ArrayConcat = require('uint8arrays/concat')
 const uint8ArrayToString = require('uint8arrays/to-string')
 const uint8ArrayEquals = require('uint8arrays/equals')
 
-const codecInts = Object.keys(codecs).reduce((p, name) => {
+const codecInts = /** @type {CodecName[]} */(Object.keys(codecs)).reduce((p, name) => {
   p[codecs[name]] = name
   return p
-}, {})
+}, /** @type {Record<CodecNumber, CodecName>} */({}))
 
 const symbol = Symbol.for('@ipld/js-cid/CID')
 
@@ -103,6 +103,7 @@ class CID {
       this.codec = cid.codec
       this.multihash = cid.multihash
       // Default guard for when a CID < 0.7 is passed with no multibaseName
+      // @ts-ignore
       this.multibaseName = cid.multibaseName || (cid.version === 0 ? 'base58btc' : 'base32')
       return
     }
@@ -154,6 +155,7 @@ class CID {
     this.version = version
 
     if (typeof codec === 'number') {
+      // @ts-ignore
       codec = codecInts[codec]
     }
 

--- a/test/cid-util.spec.js
+++ b/test/cid-util.spec.js
@@ -9,7 +9,7 @@ const CID = require('../src')
 const CIDUtil = require('../src/cid-util')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
-describe('CIDUtil', async () => {
+describe('CIDUtil', () => {
   /** @type {Uint8Array} */
   let hash
 

--- a/test/cid-util.spec.js
+++ b/test/cid-util.spec.js
@@ -10,7 +10,12 @@ const CIDUtil = require('../src/cid-util')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
 describe('CIDUtil', async () => {
-  const hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
+  /** @type {Uint8Array} */
+  let hash
+
+  before(async () => {
+    hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
+  })
 
   describe('checkCIDComponents()', () => {
     describe('returns undefined on valid CID', () => {

--- a/test/cid-util.spec.js
+++ b/test/cid-util.spec.js
@@ -3,17 +3,14 @@
 'use strict'
 
 const { expect } = require('aegir/utils/chai')
+// @ts-ignore
 const multihashing = require('multihashing-async')
 const CID = require('../src')
 const CIDUtil = require('../src/cid-util')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
-describe('CIDUtil', () => {
-  let hash
-
-  before(async () => {
-    hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
-  })
+describe('CIDUtil', async () => {
+  const hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
 
   describe('checkCIDComponents()', () => {
     describe('returns undefined on valid CID', () => {

--- a/test/helpers/gen-cid.js
+++ b/test/helpers/gen-cid.js
@@ -5,6 +5,7 @@
 
 const multibase = require('multibase')
 const codecs = require('../../src').codecs
+// @ts-ignore
 const multihashing = require('multihashing-async')
 const utf8ArrayFromString = require('uint8arrays/from-string')
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -14,8 +14,10 @@ const { deepEqual } = require('@sinonjs/samsam')
 
 describe('CID', async () => {
   /** @type {Uint8Array} */
-  const hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
-
+  let hash
+  before(async () => {
+    hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
+  })
   describe('v0', () => {
     it('handles B58Str multihash', () => {
       const mhStr = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -12,7 +12,7 @@ const uint8ArrayToString = require('uint8arrays/to-string')
 const CID = require('../src')
 const { deepEqual } = require('@sinonjs/samsam')
 
-describe('CID', async () => {
+describe('CID', () => {
   /** @type {Uint8Array} */
   let hash
   before(async () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,6 +4,7 @@
 
 const { expect } = require('aegir/utils/chai')
 const multihash = require('multihashes')
+// @ts-ignore
 const multihashing = require('multihashing-async')
 const multicodec = require('multicodec')
 const uint8ArrayFromString = require('uint8arrays/from-string')
@@ -11,12 +12,9 @@ const uint8ArrayToString = require('uint8arrays/to-string')
 const CID = require('../src')
 const { deepEqual } = require('@sinonjs/samsam')
 
-describe('CID', () => {
-  let hash
-
-  before(async () => {
-    hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
-  })
+describe('CID', async () => {
+  /** @type {Uint8Array} */
+  const hash = await multihashing(uint8ArrayFromString('abc'), 'sha2-256')
 
   describe('v0', () => {
     it('handles B58Str multihash', () => {
@@ -346,10 +344,12 @@ describe('CID', () => {
     }))
 
     invalid.forEach((i) => it(`new CID(0, 'dag-pb', ${i instanceof Uint8Array ? 'Uint8Array' : 'String'}<${i.toString()}>)`, () => {
+      // @ts-expect-error - string should throw
       expect(() => new CID(0, 'dag-pb', i)).to.throw()
     }))
 
     invalid.forEach((i) => it(`new CID(1, 'dag-pb', ${i instanceof Uint8Array ? 'Uint8Array' : 'String'}<${i.toString()}>)`, () => {
+      // @ts-expect-error - string should throw
       expect(() => new CID(1, 'dag-pb', i)).to.throw()
     }))
 

--- a/test/profiling/cidperf-x.js
+++ b/test/profiling/cidperf-x.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 'use strict'
 
+// @ts-ignore
 const multihashing = require('multihashing-async')
 // [1] Original/existing implementation.
 // const CID = require('cids')
@@ -9,6 +10,9 @@ const CID = require('../../src')
 const uint8ArrayFromString = require('uint8arrays/from-string')
 
 // Used to delay the testing for a few seconds.
+/**
+ * @param {number} ms
+ */
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
@@ -17,6 +21,9 @@ function sleep (ms) {
 // The purpose of this class is
 // to simply test the CID ctor (and, primarily, CID.isCID() method).
 class CIDPerfX {
+  /**
+   * @param {any} mh
+   */
   constructor (mh) {
     this.version = 1
     this.codec = 'dag-pb'
@@ -25,6 +32,10 @@ class CIDPerfX {
 
   // i: Running-counter.
   // print: If true, it'll print/dump the CID data.
+  /**
+   * @param {string | number} i
+   * @param {boolean | undefined} [print]
+   */
   run (i, print) {
     // @ts-ignore
     const cid = new CID(this.version, this.codec, this.mh)

--- a/test/profiling/cidperf-x.js
+++ b/test/profiling/cidperf-x.js
@@ -64,7 +64,7 @@ sleep(1000).then(async () => {
   const cidPerf = new CIDPerfX(mh);
 
   [...Array(reps).keys()].map(i => {
-    cidPerf.run(i)
+    return cidPerf.run(i)
   })
   console.timeEnd('run')
 })


### PR DESCRIPTION
This PR updates aegir and fixes errors with the new ts config and removes typesVersions.

`typesVersions` workaround makes TS rewrite imports to `cids` to `cids/src` and because this package doesn't really needs this a workaround its just removed.

This should fix https://github.com/libp2p/js-libp2p/issues/839#issuecomment-756407072