### PR TITLE
fix(api): set default base when using toV1 from V0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -256,6 +256,10 @@ class CID {
    * @returns {CID}
    */
   toV1 () {
+    if (this.version === 0) {
+      return new CID(1, this.codec, this.multihash, 'base32')
+    }
+
     return new CID(1, this.codec, this.multihash, this.multibaseName)
   }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -378,6 +378,7 @@ describe('CID', () => {
       const hash = await multihashing(uint8ArrayFromString(`TEST${Date.now()}`), 'sha2-256')
       const cid = new CID(0, 'dag-pb', hash).toV1()
       expect(cid.version).to.equal(1)
+      expect(cid.multibaseName).to.equal('base32')
     })
 
     it('should convert v1 to v0', async () => {


### PR DESCRIPTION
This PR is fix `toV1` API to set default base to base32 when convert from V0. 

More details are here.

https://github.com/multiformats/js-cid/issues/145